### PR TITLE
Adding yarn install-peers on the other github workflows

### DIFF
--- a/.github/workflows/publish-prerelease-npm.yml
+++ b/.github/workflows/publish-prerelease-npm.yml
@@ -17,6 +17,7 @@ jobs:
             node-version: 12
             registry-url: https://registry.npmjs.org/
       - run: yarn install --ignore-scripts
+      - run: yarn install-peers
       - run: yarn build
       - run: npm publish --tag beta --access public
         env:

--- a/.github/workflows/publish-stable-npm.yml
+++ b/.github/workflows/publish-stable-npm.yml
@@ -17,6 +17,7 @@ jobs:
             node-version: 12
             registry-url: https://registry.npmjs.org/
       - run: yarn install --ignore-scripts
+      - run: yarn install-peers
       - run: yarn build
       - run: npm publish --access public
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Problems of typings' conflict with `@vtex/api` version. Added as peer dependency.
 
 ## [1.0.2] - 2020-10-23
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adding yarn install-peers on the other GitHub workflows to avoid problems with `yarn build`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [ ] Update `CHANGELOG.md`