### PR TITLE
adding fields to invoice notification typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Missing fields on typing used in OMS client 
 
 ## [1.0.3] - 2020-10-23
 ### Fixed

--- a/src/typings/oms.ts
+++ b/src/typings/oms.ts
@@ -368,7 +368,7 @@ export interface NotificationResponse {
 
 export interface NotificationInput {
   type: string
-  issuanceDate: string
+  issuanceDate?: string
   invoiceNumber: string
   invoiceKey?: string
   invoiceValue: number

--- a/src/typings/oms.ts
+++ b/src/typings/oms.ts
@@ -368,13 +368,16 @@ export interface NotificationResponse {
 
 export interface NotificationInput {
   type: string
+  issuanceDate: string
   invoiceNumber: string
+  invoiceKey?: string
+  invoiceValue: number
+  invoiceUrl: string
   courier: string
   trackingNumber: string
   trackingUrl: string
+  dispatchDate?: string | null
   items: Item[]
-  issuanceDate: Date
-  invoiceValue: number
 }
 
 export interface Item {

--- a/src/typings/oms.ts
+++ b/src/typings/oms.ts
@@ -368,7 +368,7 @@ export interface NotificationResponse {
 
 export interface NotificationInput {
   type: string
-  issuanceDate?: string
+  issuanceDate: string
   invoiceNumber: string
   invoiceKey?: string
   invoiceValue: number


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix problems with invoice notification typings. This typing is used in the OMS client.

#### What problem is this solving?
Adds missing fields

#### How should this be manually tested?
Link this package on the `service-example` app

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`