### PR TITLE
Adding new methods to logistics, catalog and oms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New methods to Catalog, OMS and Logistics clients
 
 ## [2.0.0] - 2020-12-03
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ yarn add @vtex/clients
 | **Client Name** | **Implemented Methods**                                                         | Observations      |
 |-----------------|---------------------------------------------------------------------------------| -                 |
 | Affiliate       | `registerAffiliate`, `changeNotification`, `createSeller`, `getSellerList`      |                   |
-| Catalog         | `getSkuById`                                                                    | -                 |
+| Catalog         | `getProductsAndSkus`, `getSkuById`, `changeNotification`, `createSeller`, `getSellerList`| -                 |
 | Checkout        | `getOrderFormConfiguration`, `setOrderFormConfiguration`, `setSingleCustomData` | -                 |
-| Logistics       | `getDockById`, `pickupById`, `nearPickupPoints`, `shipping`                     | -                 |
-| OMS             | `userLastOrder`, `order`, `orderNotification`, `cancelOrder`                    | -                 |
+| Logistics       | `getDockById`, `pickupById`, `listPickupPoints`, `nearPickupPoints`, `shipping`                     | -                 |
+| OMS             | `listOrders`, `userLastOrder`, `order`, `orderNotification`, `cancelOrder`                    | -                 |
 | OMS Proxy       | `orders`, `orderFormId`, `customData`, `register`                               | You will have to declare a dependency and a policy on your app. You can check out [this document](https://www.notion.so/How-to-use-the-OMS-API-Proxy-application-e82f11ff896247c58a7e2e658d631516).
 | Suggestions     | `getAllSuggestions`, `getSuggestionById`, `sendSkuSuggestion`, `deleteSkuSuggestion`, `getAllVersions`, `getVersionById`| -                 |
 

--- a/src/clients/catalog.ts
+++ b/src/clients/catalog.ts
@@ -16,6 +16,7 @@ const baseURL = '/api/catalog'
 const baseURLLegacy = '/api/catalog_system'
 
 const routes = {
+  productsAndSkus: `${baseURLLegacy}/pvt/products/GetProductAndSkuIds`,
   getSkuById: (skuId: string) => `${baseURL}/pvt/stockkeepingunit/${skuId}`,
   changeNotification: (sellerId: string, skuId: string) =>
     `${baseURLLegacy}/pvt/skuseller/changenotification/${sellerId}/${skuId}`,
@@ -27,6 +28,24 @@ export class Catalog extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(ctx, {
       ...options,
+    })
+  }
+
+  public getProductsAndSkus(
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'catalog-getProductsAndSkus'
+    const token = getAuthToken(this.context, authMethod)
+
+    return this.http.get(routes.productsAndSkus, {
+      headers: token
+        ? {
+            VtexIdclientAutCookie: token,
+          }
+        : {},
+      metric,
+      tracing: createTracing(metric, tracingConfig),
     })
   }
 

--- a/src/clients/logistics.ts
+++ b/src/clients/logistics.ts
@@ -18,6 +18,7 @@ const routes = {
   nearPickupPoints: (lat: string, long: string, maxDistance: number) =>
     `${baseURL}/pvt/configuration/pickuppoints/_search?&page=1&pageSize=100&lat=${lat}&lon=${long}&maxDistance=${maxDistance}`,
   pickUpById: (id: string) => `${baseURL}/pvt/configuration/pickuppoints/${id}`,
+  pickupPoints: `${baseURL}/pvt/configuration/pickuppoints/_search`,
 }
 
 export class Logistics extends JanusClient {
@@ -55,6 +56,24 @@ export class Logistics extends JanusClient {
     const token = getAuthToken(this.context, authMethod)
 
     return this.http.get<LogisticPickupPoint>(routes.pickUpById(id), {
+      headers: token
+        ? {
+            VtexIdclientAutCookie: token,
+          }
+        : {},
+      metric,
+      tracing: createTracing(metric, tracingConfig),
+    })
+  }
+
+  public listPickupPoints(
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'logistics-listPickupPoints'
+    const token = getAuthToken(this.context, authMethod)
+
+    return this.http.get<LogisticOutput>(routes.pickupPoints, {
       headers: token
         ? {
             VtexIdclientAutCookie: token,

--- a/src/clients/oms.ts
+++ b/src/clients/oms.ts
@@ -10,6 +10,7 @@ import { createTracing } from '../utils/tracing'
 import { AuthMethod } from '../typings/tokens'
 import {
   CancelResponse,
+  ListOrdersResponse,
   NotificationInput,
   NotificationResponse,
   OrderDetailResponse,
@@ -19,6 +20,7 @@ import { OrderFormConfiguration } from '../typings/orderForm'
 const baseURL = '/api/oms'
 
 const routes = {
+  orders: `${baseURL}/pvt/orders`,
   lastOrder: `${baseURL}/user/orders/last`,
   order: (id: string) => `${baseURL}/pvt/orders/${id}`,
   notification: (id: string) => `${baseURL}/pvt/orders/${id}/invoice`,
@@ -29,6 +31,24 @@ export class OMS extends JanusClient {
   constructor(ctx: IOContext, options?: InstanceOptions) {
     super(ctx, {
       ...options,
+    })
+  }
+
+  public listOrders(
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'oms-listOrders'
+    const token = getAuthToken(this.context, authMethod)
+
+    return this.http.get<ListOrdersResponse>(routes.orders, {
+      headers: token
+        ? {
+            VtexIdclientAutCookie: token,
+          }
+        : {},
+      metric,
+      tracing: createTracing(metric, tracingConfig),
     })
   }
 

--- a/src/typings/oms.ts
+++ b/src/typings/oms.ts
@@ -391,3 +391,36 @@ export interface CancelResponse {
   orderId: string
   receipt: string
 }
+
+export interface ListOrdersResponse {
+  list: ListOrdersItem[]
+}
+
+export interface ListOrdersItem {
+  orderId: string
+  creationDate: string
+  clientName: string
+  items: Item[]
+  totalValue: number
+  paymentNames: string
+  status: string
+  statusDescription: string
+  marketPlaceOrderId: string | null
+  sequence: string
+  salesChannel: string
+  affiliateId: string
+  origin: string
+  workflowInErrorState: boolean
+  workflowInRetry: boolean
+  lastMessageUnread: string
+  ShippingEstimatedDate: string | null
+  ShippingEstimatedDateMax: string | null
+  ShippingEstimatedDateMin: string | null
+  orderIsComplete: boolean
+  listId: string | null
+  listType: any
+  authorizedDate: string
+  callCenterOperatorName: string | null
+  totalItems: number
+  currencyCode: string
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add missing methods

Implements the following methods:
- [Get Products and Skus](https://developers.vtex.com/vtex-developer-docs/reference/catalog-api-product#catalog-api-get-products-skus)
- [List of Pickup Points - paged](https://developers.vtex.com/vtex-developer-docs/reference/pickup-points#getpaged)
- [List of Orders](https://developers.vtex.com/vtex-developer-docs/reference/orders#listorders)

#### What problem is this solving?
Missing methods

#### How should this be manually tested?
Link package on `service-example` and test it

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`