### PR TITLE
Using utils function to create request config object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Using utils function to create the request config object
 
 ## [2.3.0] - 2020-12-28
 

--- a/src/clients/affiliate.ts
+++ b/src/clients/affiliate.ts
@@ -5,10 +5,9 @@ import {
   RequestTracingConfig,
 } from '@vtex/api'
 
-import { getAuthToken } from '../utils/authToken'
-import { createTracing } from '../utils/tracing'
 import { AuthMethod } from '../typings/tokens'
 import { AffiliateInput } from '../typings/affiliate'
+import { getRequestConfig } from '../utils/request'
 
 const baseURL = 'api/fulfillment/pvt/affiliates'
 const routes = {
@@ -28,7 +27,6 @@ export class Affiliate extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'affiliate-registerAffiliate'
-    const token = getAuthToken(this.context, authMethod)
 
     return this.http.put(
       routes.affiliate(id),
@@ -42,15 +40,7 @@ export class Affiliate extends JanusClient {
         searchURIEndPointVersion: '1.x.x',
         useSellerPaymentMethod: false,
       },
-      {
-        headers: token
-          ? {
-              VtexIdclientAutCookie: token,
-            }
-          : {},
-        metric,
-        tracing: createTracing(metric, tracingConfig),
-      }
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )
   }
 }

--- a/src/clients/catalog.ts
+++ b/src/clients/catalog.ts
@@ -5,11 +5,10 @@ import {
   RequestTracingConfig,
 } from '@vtex/api'
 
-import { getAuthToken } from '../utils/authToken'
-import { createTracing } from '../utils/tracing'
 import { checkSellerInformation } from '../utils/seller'
 import { AuthMethod } from '../typings/tokens'
 import { GetSkuResponse, Seller } from '../typings/catalog'
+import { getRequestConfig } from '../utils/request'
 
 const baseURL = '/api/catalog'
 const baseURLLegacy = '/api/catalog_system'
@@ -35,17 +34,11 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-getProductsAndSkus'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get(routes.productsAndSkus, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get(
+      routes.productsAndSkus,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public getSkuById(
@@ -54,17 +47,11 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-getSkuMetric'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<GetSkuResponse>(routes.getSkuById(skuId), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<GetSkuResponse>(
+      routes.getSkuById(skuId),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public changeNotification(
@@ -76,20 +63,11 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-changeNotification'
-    const token = getAuthToken(this.context, authMethod)
 
     return this.http.post(
       routes.changeNotification(sellerId, sellerSkuId),
       {},
-      {
-        headers: token
-          ? {
-              VtexIdclientAutCookie: token,
-            }
-          : {},
-        metric,
-        tracing: createTracing(metric, tracingConfig),
-      }
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )
   }
 
@@ -99,18 +77,13 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-createSeller'
-    const token = getAuthToken(this.context, authMethod)
     const sellerInfo = checkSellerInformation(seller)
 
-    return this.http.post(routes.seller(sellerInfo.SellerId), sellerInfo, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.post(
+      routes.seller(sellerInfo.SellerId),
+      sellerInfo,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public getSellerList(
@@ -118,17 +91,11 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-getSellerList'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<Seller[]>(routes.sellerList, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<Seller[]>(
+      routes.sellerList,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 }
 

--- a/src/clients/catalog.ts
+++ b/src/clients/catalog.ts
@@ -93,17 +93,11 @@ export class Catalog extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'catalog-search'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get(routes.search(query), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get(
+      routes.search(query),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public getSellerList(

--- a/src/clients/logistics.ts
+++ b/src/clients/logistics.ts
@@ -5,10 +5,9 @@ import {
   InstanceOptions,
 } from '@vtex/api'
 
-import { getAuthToken } from '../utils/authToken'
-import { createTracing } from '../utils/tracing'
 import { AuthMethod } from '../typings/tokens'
 import { LogisticOutput, LogisticPickupPoint } from '../typings/logistics'
+import { getRequestConfig } from '../utils/request'
 
 const baseURL = '/api/logistics'
 
@@ -34,17 +33,11 @@ export class Logistics extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'logistics-getDockById'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get(routes.docks(dockId), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get(
+      routes.docks(dockId),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public pickupById(
@@ -53,17 +46,11 @@ export class Logistics extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'logistics-pickupById'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<LogisticPickupPoint>(routes.pickUpById(id), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<LogisticPickupPoint>(
+      routes.pickUpById(id),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public listPickupPoints(
@@ -71,17 +58,11 @@ export class Logistics extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'logistics-listPickupPoints'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<LogisticOutput>(routes.pickupPoints, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<LogisticOutput>(
+      routes.pickupPoints,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -93,19 +74,10 @@ export class Logistics extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'logistics-nearPickupPoints'
-    const token = getAuthToken(this.context, authMethod)
 
     return this.http.get<LogisticOutput>(
       routes.nearPickupPoints(lat, long, maxDistance),
-      {
-        headers: token
-          ? {
-              VtexIdclientAutCookie: token,
-            }
-          : {},
-        metric,
-        tracing: createTracing(metric, tracingConfig),
-      }
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )
   }
 
@@ -114,16 +86,10 @@ export class Logistics extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'logistics-shipping'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<LogisticPickupPoint>(routes.shipping, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<LogisticPickupPoint>(
+      routes.shipping,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 }

--- a/src/clients/oms.ts
+++ b/src/clients/oms.ts
@@ -5,8 +5,6 @@ import {
   RequestTracingConfig,
 } from '@vtex/api'
 
-import { getAuthToken } from '../utils/authToken'
-import { createTracing } from '../utils/tracing'
 import { AuthMethod } from '../typings/tokens'
 import {
   CancelResponse,
@@ -16,6 +14,7 @@ import {
   OrderDetailResponse,
 } from '../typings/oms'
 import { OrderFormConfiguration } from '../typings/orderForm'
+import { getRequestConfig } from '../utils/request'
 
 const baseURL = '/api/oms'
 
@@ -39,17 +38,11 @@ export class OMS extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'oms-listOrders'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<ListOrdersResponse>(routes.orders, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<ListOrdersResponse>(
+      routes.orders,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public userLastOrder(
@@ -57,17 +50,11 @@ export class OMS extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'oms-userLastOrder'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<OrderFormConfiguration>(routes.lastOrder, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<OrderFormConfiguration>(
+      routes.lastOrder,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public order(
@@ -76,17 +63,11 @@ export class OMS extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'oms-order'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<OrderDetailResponse>(routes.order(id), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<OrderDetailResponse>(
+      routes.order(id),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -97,17 +78,12 @@ export class OMS extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'oms-orderNotification'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.post<NotificationResponse>(routes.notification(id), body, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.post<NotificationResponse>(
+      routes.notification(id),
+      body,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   public cancelOrder(
@@ -116,16 +92,10 @@ export class OMS extends JanusClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'oms-cancelOrder'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.post<CancelResponse>(routes.cancel(id), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.post<CancelResponse>(
+      routes.cancel(id),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 }

--- a/src/clients/suggestions.ts
+++ b/src/clients/suggestions.ts
@@ -5,14 +5,13 @@ import {
   RequestTracingConfig,
 } from '@vtex/api'
 
-import { getAuthToken } from '../utils/authToken'
-import { createTracing } from '../utils/tracing'
 import { AuthMethod } from '../typings/tokens'
 import {
   Suggestion,
   SuggestionRequest,
   SuggestionsResponse,
 } from '../typings/suggestions'
+import { getRequestConfig } from '../utils/request'
 
 const routes = {
   sellerSkuId: (sellerId: string, sellerSkuId: string) =>
@@ -35,17 +34,11 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-getAllSuggestions'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get<SuggestionsResponse>('', {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get<SuggestionsResponse>(
+      '',
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -56,19 +49,10 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-getSuggestionById'
-    const token = getAuthToken(this.context, authMethod)
 
     return this.http.get<Suggestion>(
       routes.sellerSkuId(sellerId, sellerSkuId),
-      {
-        headers: token
-          ? {
-              VtexIdclientAutCookie: token,
-            }
-          : {},
-        metric,
-        tracing: createTracing(metric, tracingConfig),
-      }
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )
   }
 
@@ -79,18 +63,13 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-sendSkuSuggestion'
-    const token = getAuthToken(this.context, authMethod)
     const { SellerId: sellerId, SellerStockKeepingUnitId: sellerSkuId } = body
 
-    return this.http.put(routes.sellerSkuId(sellerId, sellerSkuId), body, {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.put(
+      routes.sellerSkuId(sellerId, sellerSkuId),
+      body,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -101,17 +80,11 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-deleteSkuSuggestion'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.delete(routes.sellerSkuId(sellerId, sellerSkuId), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.delete(
+      routes.sellerSkuId(sellerId, sellerSkuId),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -122,17 +95,11 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-deleteSkuSuggestion'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get(routes.versions(sellerId, sellerSkuId), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get(
+      routes.versions(sellerId, sellerSkuId),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 
   // eslint-disable-next-line max-params
@@ -144,16 +111,10 @@ export class Suggestions extends ExternalClient {
     tracingConfig?: RequestTracingConfig
   ) {
     const metric = 'suggestions-deleteSkuSuggestion'
-    const token = getAuthToken(this.context, authMethod)
 
-    return this.http.get(routes.versionById(sellerId, sellerSkuId, version), {
-      headers: token
-        ? {
-            VtexIdclientAutCookie: token,
-          }
-        : {},
-      metric,
-      tracing: createTracing(metric, tracingConfig),
-    })
+    return this.http.get(
+      routes.versionById(sellerId, sellerSkuId, version),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
For each client was made a refactor in order to change the way we create the request config body. It now uses the utils function that @gsasouza implemented

#### What problem is this solving?
Better readability

#### How should this be manually tested?
Link the package on `service-example` app and use it

#### Types of changes
- [x] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`