### PR TITLE
Fix/schema name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Remove state hash from schema name
 
 ## [2.7.0] - 2021-03-01
 
@@ -58,7 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.4] - 2020-11-09
 ### Fixed
-- Missing fields on typing used in OMS client 
+- Missing fields on typing used in OMS client
 
 ## [1.0.3] - 2020-10-23
 ### Fixed

--- a/src/clients/masterData/masterDataFactory.ts
+++ b/src/clients/masterData/masterDataFactory.ts
@@ -82,8 +82,14 @@ const GLOBAL = ''
  */
 const normalizeEntityName = (str: string) => str.replace(/(\.)|-|:/gi, '_')
 
+const removeStateHash = (workspace: string): string => {
+  const index = workspace.lastIndexOf('-')
+
+  return index === -1 ? workspace : workspace.substring(0, index)
+}
+
 const versionDescriptor = (isProduction: boolean, workspace: string) =>
-  isProduction ? GLOBAL : `-${workspace}`
+  isProduction ? GLOBAL : `-${removeStateHash(workspace)}`
 
 export const masterDataFor = <TEntity extends Record<string, any>>(
   entityName: string,


### PR DESCRIPTION
#### What is the purpose of this pull request?
It fixes the schema name for development workspaces when there is a state hash (from progressive rollout) appended to the workspace.

#### What problem is this solving?
If you link an app using the masterdata factory in a account with progressive rollout enabled you won't be able to find any document because the generated schema name includes the state hash

ex:
`0.4.0-brunoh-a571df1d848b3881cd5bcd3ad3b77155` instead of `0.4.0-brunoh`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`