### PR TITLE
Fixes catalog client response typo `id` -> `Id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Catalog client GetSkuResponse `id` -> `Id` typo
+
 ## [2.7.0] - 2021-03-01
 
 ### Fixed

--- a/src/typings/catalog.ts
+++ b/src/typings/catalog.ts
@@ -42,7 +42,7 @@ export interface SKU {
 }
 
 export interface GetSkuResponse {
-  id: number
+  Id: number
   ProductId: number
   IsActive: boolean
   Name: string


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix a typo which doesn't allow us to use the correct property
![image](https://user-images.githubusercontent.com/5959178/110044750-6e711280-7d28-11eb-8a01-9377e7225eea.png)

#### What problem is this solving?
Correct typings to be consistent with [catalog's API response](https://developers.vtex.com/vtex-developer-docs/reference/catalog-api-sku#catalog-api-get-sku)

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/5959178/110044534-11755c80-7d28-11eb-90e1-23a5f5a2f938.png)
![image](https://user-images.githubusercontent.com/5959178/110044580-2651f000-7d28-11eb-90b2-5c77cd5fa31e.png)

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [X] Update `CHANGELOG.md`