### PR TITLE
Fix/fix list inventory by SKU return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Fix the response type for the `listInventoryBySku` method in the Logistics client
 
 ## [2.15.0] - 2021-07-08
 ### Added

--- a/src/clients/logistics.ts
+++ b/src/clients/logistics.ts
@@ -6,7 +6,11 @@ import type {
 import { JanusClient } from '@vtex/api'
 
 import type { AuthMethod } from '../typings/tokens'
-import type { LogisticOutput, LogisticPickupPoint } from '../typings/logistics'
+import type {
+  LogisticOutput,
+  LogisticPickupPoint,
+  InventoryBySkuResponse,
+} from '../typings/logistics'
 import { getRequestConfig } from '../utils/request'
 
 const baseURL = '/api/logistics'
@@ -102,7 +106,7 @@ export class Logistics extends JanusClient {
   ) {
     const metric = 'logistics-listInventoryBySku'
 
-    return this.http.get<LogisticPickupPoint>(
+    return this.http.get<InventoryBySkuResponse>(
       routes.listInventoryBySku(skuId),
       getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the response type for the listInventoryBySku method in the Logistics client

#### What problem is this solving?
Just fix the return type, i made a mistake on the last PR

#### How should this be manually tested?

- Create a simple IO service
- Import io-clients locally
- Call the new methods

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`