### PR TITLE
Fix/price definition typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Fix `priceDefinition` field typo in the `OrderItemDetailResponse` interface
 
 ## [2.15.1] - 2021-07-08
 ### Changed

--- a/src/typings/oms.ts
+++ b/src/typings/oms.ts
@@ -256,7 +256,7 @@ export interface OrderItemDetailResponse {
   shippingPrice: any
   rewardValue: number
   freightCommission: number
-  priceDefinitions: any
+  priceDefinition: any
   taxCode: string
   productCategories: any
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix the `priceDefinition` field typo in the `OrderItemDetailResponse` interface. It's name was changed in the core library months ago (`priceDefinitions` to `priceDefinition`).

#### What problem is this solving?

Prevent Typescript compile error when accessing `priceDefinition` in `OrderItemDetailResponse` objects

#### How should this be manually tested?

- Create a simple IO service
- Import io-clients locally
- Try to access `priceDefinition` in `OrderItemDetailResponse` objects

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`