### PR TITLE
Add conditions api client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- conditions client
+
 ## [2.18.0] - 2021-12-10
 
 ## [2.17.0] - 2021-07-26

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-params */
-import { Condition, ListConditionsResponse } from './../typings/conditions';
+import { Condition, ListConditionsResponse } from './../typings/conditions'
 
 import type { InstanceOptions, IOContext } from '@vtex/api'
 import { JanusClient } from '@vtex/api'

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-params */
-import { Condition, ListConditionsResponse } from './../typings/conditions'
 
 import type { InstanceOptions, IOContext } from '@vtex/api'
 import { JanusClient } from '@vtex/api'
 
+import type { Condition, ListConditionsResponse } from '../typings/conditions'
 import { getRequestConfig } from '../utils/request'
 import type { AuthMethod } from '../typings'
 

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -1,0 +1,102 @@
+/* eslint-disable max-params */
+import { Condition, ListConditionsResponse } from './../typings/conditions';
+
+import type { InstanceOptions, IOContext } from '@vtex/api'
+import { JanusClient } from '@vtex/api'
+
+import { getRequestConfig } from '../utils/request'
+import type { AuthMethod } from '../typings'
+
+export class ConditionsClient extends JanusClient {
+  constructor(ctx: IOContext, options?: InstanceOptions) {
+    super(ctx, {
+      ...options,
+    })
+  }
+
+  public getAllConditionsPerType(
+    type: string,
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'conditions-getPerType'
+
+    return this.http.get<ListConditionsResponse>(
+      this.routes.ConditionsByType(this.context.account, type),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
+  }
+
+  public getConditionById(
+    type: string,
+    id: string,
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'conditions-getById'
+
+    return this.http.get<Condition>(
+      this.routes.ConditionsById(this.context.account, type, id),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
+  }
+
+  public deleteConditionById(
+    type: string,
+    id: string,
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'conditions-getById'
+
+    return this.http.delete(
+      this.routes.ConditionsById(this.context.account, type, id),
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
+  }
+
+  public saveCondition(
+    type: string,
+    condition: Record<string, any>,
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'conditions-saveCondition'
+
+    const requestMethod =
+      'conditionId' in condition ? this.http.put : this.http.post
+
+    return requestMethod<Condition>(
+      this.routes.ConditionsById(this.context.account, type, id),
+      condition,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
+  }
+
+  public doEvaluation(
+    type: string,
+    subject: Record<string, any>,
+    authMethod: AuthMethod = 'AUTH_TOKEN',
+    tracingConfig?: RequestTracingConfig
+  ) {
+    const metric = 'conditions-doEvaluation'
+
+    return this.http.post(
+      this.routes.ApplyConditions(this.context.account, type),
+      subject,
+      getRequestConfig(this.context, authMethod, metric, tracingConfig)
+    )
+  }
+
+  private get routes() {
+    return {
+      ApplyConditions: (an: string, type: string) =>
+        `${this.routes.Conditions(an)}/evaluate/${type}`,
+      ConditionsById: (an: string, type: string, id: string) =>
+        `${this.routes.ConditionsByType(an, type)}/condition/${id}`,
+      ConditionsByType: (an: string, type: string) =>
+        `${this.routes.Conditions(an)}/${type}/condition`,
+      Conditions: (an: string) => `/${an}/conditions`,
+    }
+  }
+}

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -1,7 +1,10 @@
-/* eslint-disable max-params */
-
-import type { InstanceOptions, IOContext } from '@vtex/api'
 import { JanusClient } from '@vtex/api'
+import type {
+  RequestTracingConfig,
+  InstanceOptions,
+  IOContext,
+} from '@vtex/api'
+/* eslint-disable max-params */
 
 import type { Condition, ListConditionsResponse } from '../typings/conditions'
 import { getRequestConfig } from '../utils/request'

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -50,7 +50,7 @@ export class ConditionsClient extends JanusClient {
     authMethod: AuthMethod = 'AUTH_TOKEN',
     tracingConfig?: RequestTracingConfig
   ) {
-    const metric = 'conditions-getById'
+    const metric = 'conditions-deleteById'
 
     return this.http.delete(
       this.routes.ConditionsById(this.context.account, type, id),

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -70,7 +70,7 @@ export class ConditionsClient extends JanusClient {
       'conditionId' in condition ? this.http.put : this.http.post
 
     return requestMethod<Condition>(
-      this.routes.ConditionsById(this.context.account, type, id),
+      this.routes.ConditionsByType(this.context.account, type),
       condition,
       getRequestConfig(this.context, authMethod, metric, tracingConfig)
     )

--- a/src/typings/conditions.ts
+++ b/src/typings/conditions.ts
@@ -1,0 +1,37 @@
+export interface DateRange {
+  from: string
+  to: string
+}
+
+export interface ComponentRepresentation {
+  operator: string
+  statements: string
+}
+
+export interface ConditionMetadata {
+  template: string
+  statements: Record<string, string>
+  createdAt: string
+  modifiedAt: string
+  expressionHash: string
+  expressionVersion: string
+  operator: string
+  componentRepresentation: ComponentRepresentation
+}
+
+export interface Condition {
+  conditionId: string
+  description: string
+  expression: string
+  isEnabled: boolean
+  isFeatured: boolean
+  visualRepresentation: string
+  dateRange: DateRange
+  conditionMetadata: ConditionMetadata
+}
+
+export interface ListConditionsResponse {
+  conditionsLimit: number
+  conditions: Condition[]
+  eligible: string[]
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add conditions API client to vtex clients.

#### What problem is this solving?
We want to use the conditions client in multiple services and adding it to this npm package will avoid code duplication.

#### How should this be manually tested?

You can import it as any other commerce client:

```
    public get conditions() {
       return this.getOrSet('conditions', Conditions)
     }
```

Then, use the operations supported:

```
ctx.clients.conditions.getAllConditionsPerType(..)
ctx.clients.conditions.getConditionById(..)
ctx.clients.conditions.deleteConditionById(..)
ctx.clients.conditions.saveCondition(..)
ctx.clients.conditions.doEvaluation(..)
```

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`