### PR TITLE
Remove duplicate in condition route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Condition by id route
+
 ## [2.19.3] - 2022-02-02
 
 - Strong typing conditions response

--- a/src/clients/conditions.ts
+++ b/src/clients/conditions.ts
@@ -100,7 +100,7 @@ export class Conditions extends JanusClient {
       ApplyConditions: (an: string, type: string) =>
         `${this.routes.Conditions(an)}/${type}/evaluate`,
       ConditionsById: (an: string, type: string, id: string) =>
-        `${this.routes.ConditionsByType(an, type)}/condition/${id}`,
+        `${this.routes.ConditionsByType(an, type)}/${id}`,
       ConditionsByType: (an: string, type: string) =>
         `${this.routes.Conditions(an)}/${type}/condition`,
       Conditions: (an: string) => `/${an}/conditions`,


### PR DESCRIPTION
#### What is the purpose of this pull request?

When getting conditions by id, we are duplicate the `conditions` string in the route path.

#### What problem is this solving?
When getting conditions by id, we are duplicate the `conditions` string in the route path.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`