### PR TITLE
Feature/add where param to md scroll method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- "where" param to the Master Data scoll function
+
 ## [2.19.4] - 2022-02-08
 
 ### Fixed

--- a/src/clients/masterData/masterDataFactory.ts
+++ b/src/clients/masterData/masterDataFactory.ts
@@ -49,6 +49,7 @@ export type WithMetadata<TEntity extends Record<string, any>> = TEntity &
 type ScrollInput<K> = {
   fields: Array<ThisType<K> | '_all'>
   sort?: string
+  where?: string
   size?: number
   mdToken?: string
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

This PR adds the "where" param to the MasterData scroll function. 
The new version of the client inside the @vtex/api (6.45.12) adds this param so we can use it here too. 

#### How should this be manually tested?

- Create a simple IO service
- Import io-clients locally
- Call the scroll method of MD with a where filter

#### Screenshots or example usage

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`